### PR TITLE
Support zabbix-agent2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,21 @@ all:
 install: install-agent-config install-script
 
 install-agent-config:
-	install -o root -g root -m 644 userparameter_nvidia-smi.conf.linux \
-		/etc/zabbix/zabbix_agentd.d/userparameter_nvidia-smi.conf
+	@installed=false; \
+	if [ -d "/etc/zabbix/zabbix_agent2.d" ]; then \
+		install -o root -g root -m 644 userparameter_nvidia-smi.conf.linux \
+			/etc/zabbix/zabbix_agent2.d/userparameter_nvidia-smi.conf; \
+		installed=true; \
+	fi; \
+	if [ -d "/etc/zabbix/zabbix_agentd.d" ]; then \
+		install -o root -g root -m 644 userparameter_nvidia-smi.conf.linux \
+			/etc/zabbix/zabbix_agentd.d/userparameter_nvidia-smi.conf; \
+		installed=true; \
+	fi; \
+	if [ "$$installed" = "false" ]; then \
+		echo "Error: Neither zabbix-agent nor zabbix-agent2 directory found"; \
+		exit 1; \
+	fi
 
 install-script:
 	install -d -o root -g root -m 755 /etc/zabbix/scripts


### PR DESCRIPTION
We are moving to zabbix-agent2 recently. This PR adds support for zabbix-agent2 by ensuring compatibility with the zabbix-agent2.d configuration folder.